### PR TITLE
Set python base container image to 3.11

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-bullseye
+FROM python:3.11-bullseye
 
 RUN apt-get update && apt-get install -y openjdk-11-jdk
 


### PR DESCRIPTION
Fixing python image for Jupyter container to 3.11 as upgrade to python 3.12 upsteam breaks pip install of deltalake